### PR TITLE
Fix duplicate CSS property

### DIFF
--- a/css/algolia-instantsearch.css
+++ b/css/algolia-instantsearch.css
@@ -9,7 +9,6 @@
 
 #ais-facets {
 	width: 40%;
-	padding: 5%;
 	padding: 1rem;
 }
 


### PR DESCRIPTION
Fix duplicate CSS property in wp-search-with-algolia/css/algolia-instantsearch.css